### PR TITLE
Fix MediaWiki 1.44 & 1.43 & 1.42 compatibility

### DIFF
--- a/SpecialUpload.php
+++ b/SpecialUpload.php
@@ -1,7 +1,9 @@
 <?php
 namespace Avatar;
 
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Xml\Xml;
 
 class SpecialUpload extends \SpecialPage {
 
@@ -39,7 +41,7 @@ class SpecialUpload extends \SpecialPage {
 	}
 
 	private function displayMessage($msg) {
-		$this->getOutput()->addHTML(\Html::rawElement('div', array('class' => 'error', 'id' => 'errorMsg'), $msg));
+		$this->getOutput()->addHTML(Html::rawElement('div', array('class' => 'error', 'id' => 'errorMsg'), $msg));
 	}
 
 	private function processUpload() {
@@ -114,17 +116,17 @@ class SpecialUpload extends \SpecialPage {
 
 	public function displayForm() {
 		$html = '<p></p>';
-		$html .= \Html::hidden('avatar', '');
+		$html .= Html::hidden('avatar', '');
 
-		$html .= \Xml::element('button', array('id' => 'pickfile'), $this->msg('uploadavatar-selectfile'));
+		$html .= Xml::element('button', array('id' => 'pickfile'), $this->msg('uploadavatar-selectfile'));
 
 		$html .= ' ';
 
 		// Submit button
-		$html .= \Xml::submitButton($this->msg('uploadavatar-submit')->text());
+		$html .= Xml::submitButton($this->msg('uploadavatar-submit')->text());
 
 		// Wrap with a form
-		$html = \Xml::tags('form', array('action' => $this->getPageTitle()->getLinkURL(), 'method' => 'post'), $html);
+		$html = Xml::tags('form', array('action' => $this->getPageTitle()->getLinkURL(), 'method' => 'post'), $html);
 
 		$this->getOutput()->addWikiMsg('uploadavatar-notice');
 		$this->getOutput()->addHTML($html);

--- a/SpecialView.php
+++ b/SpecialView.php
@@ -33,7 +33,7 @@ class SpecialView extends \SpecialPage {
 
 		// Parse user
 		$user = $opt->getValue('user');
-		$userObj = \User::newFromName($user);
+		$userObj = MediaWikiServices::getInstance()->getUserFactory()->newFromName($user);
 		$userExists = $userObj && $userObj->getId() !== 0;
 
 		// If current task is delete and user is not allowed
@@ -89,22 +89,21 @@ class SpecialView extends \SpecialPage {
 		// This is essential as we need to submit the form to this page
 		$html = Html::hidden('title', $this->getPageTitle());
 
-		$html .= Xml::inputLabel(
-			$this->msg('viewavatar-username')->text(),
-			'user',
-			'',
-			45,
-			$user,
-			array('class' => 'mw-autocomplete-user') # This together with mediawiki.userSuggest will give us an auto completion
-		);
+		$html .= Html::label($this->msg('viewavatar-username')->text(), 'ext-avatar-username');
+		$html .= Html::input('user', $user, 'text', [
+			'class' => 'mw-autocomplete-user',
+			'size' => 45,
+			'id' => 'ext-avatar-username', # This together with mediawiki.userSuggest will give us an auto completion
+		]);
 
 		$html .= ' ';
 
 		// Submit button
-		$html .= Xml::submitButton($this->msg('viewavatar-submit')->text());
+		$html .= Html::submitButton($this->msg('viewavatar-submit')->text());
 
-		// Fieldset
-		$html = Xml::fieldset($this->msg('viewavatar-legend')->text(), $html);
+		// Warp Fieldset
+		$legend = Html::element('legend', [], $this->msg('viewavatar-legend')->text());
+		$html = Html::openElement('fieldset') . $legend . $html . Html::closeElement('fieldset');
 
 		// Wrap with a form
 		$html = Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
@@ -120,20 +119,17 @@ class SpecialView extends \SpecialPage {
 		$html .= Html::hidden('delete', 'true');
 		$html .= Html::hidden('user', $user);
 
-		$html .= Xml::inputLabel(
-			$this->msg('viewavatar-delete-reason')->text(),
-			'reason',
-			'',
-			45
-		);
+		$html .= Html::label($this->msg('viewavatar-delete-reason')->text(), 'ext-avatar-reason');
+		$html .= Html::input('reason', '', 'text', ['size' => 45, 'id' => 'ext-avatar-reason']);
 
 		$html .= ' ';
 
 		// Submit button
-		$html .= Xml::submitButton($this->msg('viewavatar-delete-submit')->text());
+		$html .= Html::submitButton($this->msg('viewavatar-delete-submit')->text());
 
-		// Fieldset
-		$html = Xml::fieldset($this->msg('viewavatar-delete-legend')->text(), $html);
+		// Warp Fieldset
+		$legend = Html::element('legend', [], $this->msg('viewavatar-delete-legend')->text());
+		$html = Html::openElement('fieldset') . $legend . $html . Html::closeElement('fieldset');
 
 		// Wrap with a form
 		$html = Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);

--- a/SpecialView.php
+++ b/SpecialView.php
@@ -1,7 +1,10 @@
 <?php
 namespace Avatar;
 
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Xml\Xml;
 
 class SpecialView extends \SpecialPage {
 
@@ -22,7 +25,7 @@ class SpecialView extends \SpecialPage {
 		$this->outputHeader();
 
 		// Parse options
-		$opt = new \FormOptions;
+		$opt = new FormOptions;
 		$opt->add('user', '');
 		$opt->add('delete', '');
 		$opt->add('reason', '');
@@ -61,11 +64,11 @@ class SpecialView extends \SpecialPage {
 			$haveAvatar = Avatars::hasAvatar($userObj);
 
 			if ($haveAvatar) {
-				$html = \Xml::tags('img', array(
+				$html = Xml::tags('img', array(
 					'src' => Avatars::getLinkFor($user, 'original') . '&nocache&ver=' . dechex(time()),
 					'height' => 400,
 				), '');
-				$html = \Xml::tags('p', array(), $html);
+				$html = Xml::tags('p', array(), $html);
 				$this->getOutput()->addHTML($html);
 
 				// Add a delete button
@@ -84,9 +87,9 @@ class SpecialView extends \SpecialPage {
 		global $wgScript;
 
 		// This is essential as we need to submit the form to this page
-		$html = \Html::hidden('title', $this->getPageTitle());
+		$html = Html::hidden('title', $this->getPageTitle());
 
-		$html .= \Xml::inputLabel(
+		$html .= Xml::inputLabel(
 			$this->msg('viewavatar-username')->text(),
 			'user',
 			'',
@@ -98,13 +101,13 @@ class SpecialView extends \SpecialPage {
 		$html .= ' ';
 
 		// Submit button
-		$html .= \Xml::submitButton($this->msg('viewavatar-submit')->text());
+		$html .= Xml::submitButton($this->msg('viewavatar-submit')->text());
 
 		// Fieldset
-		$html = \Xml::fieldset($this->msg('viewavatar-legend')->text(), $html);
+		$html = Xml::fieldset($this->msg('viewavatar-legend')->text(), $html);
 
 		// Wrap with a form
-		$html = \Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
+		$html = Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
 
 		$this->getOutput()->addHTML($html);
 	}
@@ -113,11 +116,11 @@ class SpecialView extends \SpecialPage {
 		global $wgScript;
 
 		// This is essential as we need to submit the form to this page
-		$html = \Html::hidden('title', $this->getPageTitle());
-		$html .= \Html::hidden('delete', 'true');
-		$html .= \Html::hidden('user', $user);
+		$html = Html::hidden('title', $this->getPageTitle());
+		$html .= Html::hidden('delete', 'true');
+		$html .= Html::hidden('user', $user);
 
-		$html .= \Xml::inputLabel(
+		$html .= Xml::inputLabel(
 			$this->msg('viewavatar-delete-reason')->text(),
 			'reason',
 			'',
@@ -127,13 +130,13 @@ class SpecialView extends \SpecialPage {
 		$html .= ' ';
 
 		// Submit button
-		$html .= \Xml::submitButton($this->msg('viewavatar-delete-submit')->text());
+		$html .= Xml::submitButton($this->msg('viewavatar-delete-submit')->text());
 
 		// Fieldset
-		$html = \Xml::fieldset($this->msg('viewavatar-delete-legend')->text(), $html);
+		$html = Xml::fieldset($this->msg('viewavatar-delete-legend')->text(), $html);
 
 		// Wrap with a form
-		$html = \Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
+		$html = Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
 
 		$this->getOutput()->addHTML($html);
 	}

--- a/avatar.php
+++ b/avatar.php
@@ -2,6 +2,8 @@
 
 // For some configurations, extensions are symbolic linked
 // This is the workaround for ../..
+use MediaWiki\MediaWikiServices;
+
 $dir = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
 
 // This switches working directory to the root directory of MediaWiki.
@@ -28,7 +30,7 @@ if (isset($query['user'])) {
 		$res = $wgDefaultAvatarRes;
 	}
 
-	$user = User::newFromName($username);
+	$user = MediaWikiServices::getInstance()->getUserFactory()->newFromName($username);
 	if ($user) {
 		$path = \Avatar\Avatars::getAvatar($user, $res);
 	}


### PR DESCRIPTION
1. The alias for Html and FormOptions has been removed in MW 1.44
2. The alias for Xml has been deprecated in MW 1.43
3. Xml::inputLabel(), Xml::fieldset() and Xml::submitButton() has been deprecated in MW 1.42